### PR TITLE
feat: color car by rank

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,6 +345,7 @@
       default: return '#999';
     }
   }
+  let currentRankColor = rankColor(0);
   function rankBadgeDataURI(idx, big=false){
     const col = rankColor(idx);
     const size = big?120:18;
@@ -395,6 +396,7 @@
     rankNowIcon.src = rankBadgeDataURI(idx);
     rankText.textContent = `Rank: ${RANKS[idx] || 'Unrated'}`;
     rrText.textContent = `RR: ${Math.max(0, Math.min(100, Math.round(rrVal ?? 0)))}`;
+    setCarColor(rankColor(idx));
   }
 
   async function applyMatchResultAndSave(name, scoreVal, elapsedMs){
@@ -665,33 +667,41 @@
     const rwing = new THREE.Mesh(new THREE.BoxGeometry(2.4,0.15,0.6), bodyMat); rwing.position.set(0, 1.15, -2.8); g.add(rwing);
     const rwingVert = new THREE.Mesh(new THREE.BoxGeometry(0.2,0.7,0.05), bodyMat); rwingVert.position.set(0, 1.0, -2.6); g.add(rwingVert);
     const nose = new THREE.Mesh(new THREE.ConeGeometry(0.5,1.2,14), bodyMat); nose.rotation.x = Math.PI; nose.position.set(0,0.95,3.5); g.add(nose);
+    g.userData.colorMats = [bodyMat];
     return g;
   }
   function makeTailCar(primary=0xff8a00, trim=0x333333){
     const g = new THREE.Group();
-    const body = new THREE.Mesh(new THREE.BoxGeometry(1.8,0.5,4.2),
-      new THREE.MeshStandardMaterial({color:primary, metalness:.4, roughness:.4}));
+    const bodyMat = new THREE.MeshStandardMaterial({color:primary, metalness:.4, roughness:.4});
+    const body = new THREE.Mesh(new THREE.BoxGeometry(1.8,0.5,4.2), bodyMat);
     body.position.set(0,0.85,0); g.add(body);
     const bump = new THREE.Mesh(new THREE.BoxGeometry(0.8,0.35,0.9),
       new THREE.MeshStandardMaterial({color:0xffffff, metalness:.2, roughness:.6}));
     bump.position.set(0,1.1,0.6); g.add(bump);
-    const wing = new THREE.Mesh(new THREE.BoxGeometry(1.6,0.12,0.45),
-      new THREE.MeshStandardMaterial({color:primary, metalness:.4, roughness:.4}));
+    const wing = new THREE.Mesh(new THREE.BoxGeometry(1.6,0.12,0.45), bodyMat);
     wing.position.set(0,1.05,-2.1); g.add(wing);
     const wheelMat = new THREE.MeshStandardMaterial({color:trim, metalness:.3, roughness:.6});
     const wheelGeo = new THREE.CylinderGeometry(0.5,0.5,0.3,14);
     const w1 = new THREE.Mesh(wheelGeo, wheelMat), w2 = new THREE.Mesh(wheelGeo, wheelMat);
     w1.rotation.z = Math.PI/2; w2.rotation.z = Math.PI/2;
     w1.position.set(-1.1,0.6,0.8); w2.position.set(1.1,0.6,0.8); g.add(w1); g.add(w2);
+    g.userData.colorMats = [bodyMat];
     return g;
   }
 
   // Cars
   const cars = [];
+  function setCarColor(color){
+    currentRankColor = color;
+    for (const c of cars){
+      const mats = c.mesh.userData && c.mesh.userData.colorMats;
+      if (mats){ mats.forEach(m=>m.color.set(color)); }
+    }
+  }
   cars.push({
     position: new THREE.Vector3(0,0,0),
     rotationY: 0,
-    mesh: makeHeadCar(0xff2d55, 0xbfd8ff),
+    mesh: makeHeadCar(currentRankColor, 0xbfd8ff),
     boost: {active:false, cooldown:0, timer:0}
   });
   scene.add(cars[0].mesh);
@@ -702,7 +712,7 @@
     const follower = {
       position: new THREE.Vector3().copy(leader.position),
       rotationY: leader.rotationY,
-      mesh: makeTailCar(0xff8a00, 0x222222),
+      mesh: makeTailCar(currentRankColor, 0x222222),
     };
     const back = new THREE.Vector3(0,0,-SEGMENT_DISTANCE).applyAxisAngle(new THREE.Vector3(0,1,0), leader.rotationY);
     follower.position.add(back);


### PR DESCRIPTION
## Summary
- color car using player's rank color
- expose car body materials for runtime color updates

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991b32536c8328927fbf0a1cedf067